### PR TITLE
Reverse order of environment variable description to match behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use `--suffix` to apply file syntax highlighting.
 
 ## Environment Variables
 
-**pyvipe** chooses the editor to use via looking for editors which are `/usr/bin/editor`, `$EDITOR`, `$VISUAL`, in order.
+**pyvipe** chooses the editor to use with the environment variable `$VISUAL`. If it is unset, it uses `$EDITOR`. If both are unset, it uses  `/usr/bin/editor` if it exists. If none of those work, it defaults to vi.
 
 ## CONTRIBUTION
 


### PR DESCRIPTION
In this code:

https://github.com/Constantin1489/pyvipe/blob/e14984e5634f2e089e3203b0caa61e75fe57b8e2/pyvipe/pyvipe.py#L42-L50

It checks `/usr/bin/editor`, `EDITOR`, and `VISUAL`, in that order. But in terms of priority, `VISUAL` is more important than `EDITOR`. For that reason, I think the associated documentation is confusing.

Cool project, by the way.